### PR TITLE
Fixed name of Plantoid DLC

### DIFF
--- a/config/dlc_list.cwt
+++ b/config/dlc_list.cwt
@@ -1,6 +1,6 @@
 enums = {
 	enum[DLCs] = {
-		"Plantoids Species Pack"
+		"Plantoid"
 		"Utopia"
 		"Synthetic Dawn Story Pack"
 		"Apocalypse"


### PR DESCRIPTION
Fixed name of Plantoid dlc as used in game scripted triggers.  The game has no reference to "Plantoids Species Pack" but does reference "Plantoid"