### PR TITLE
Included country scope for Habitability category

### DIFF
--- a/config/modifier_categories.cwt
+++ b/config/modifier_categories.cwt
@@ -24,7 +24,7 @@ modifier_categories = {
         supported_scopes = { megastructure country }
     }
     Habitability = {
-        supported_scopes = { species planet }
+        supported_scopes = { species planet country }
     }
     Starbases = {
         supported_scopes = { starbase country }


### PR DESCRIPTION
Specifically, the pop_environment_tolerance modifier is categorized as Habitability and used in Country scope in vanilla (e.g. Dynamic Ecomorphism tradition or some colonization techs), but I was getting errors when trying to use it in that scope. Just added the extra scope for that category.