### PR TITLE
push the correct scope for the modify_species effect block

### DIFF
--- a/config/effects.cwt
+++ b/config/effects.cwt
@@ -1489,6 +1489,7 @@ alias[effect:modify_species] = {
 	## cardinality = 0..1
 	portrait = random
 	## cardinality = 0..1
+	## push_scope = species
 	effect = {
 		alias_name[effect] = alias_match_left[effect]
 	}


### PR DESCRIPTION
Push the correct scope for the `modify_species = { effect = { } }` block.