### PR TITLE
Multiple desc elements are allowed as of 3.1 (with triggers)

### DIFF
--- a/config/common/districts.cwt
+++ b/config/common/districts.cwt
@@ -24,7 +24,7 @@ types = {
 district = {
 	base_buildtime = int
 
-	## cardinality = 0..1
+	## cardinality = 0..inf
 	desc = {
 		trigger = {
 			alias_name[trigger] = alias_match_left[trigger]


### PR DESCRIPTION
Multiple `desc` elements are allowed as of 3.1 - seems primarily to support the new district set for the shattered ringworld start "planet."