### PR TITLE
Feature/new fields change species characteristics

### DIFF
--- a/config/effects.cwt
+++ b/config/effects.cwt
@@ -1805,6 +1805,15 @@ alias[effect:change_species_characteristics] = {
 	## cardinality = 0..1
 	###optional, pushes out other traits if needed
 	add_traits_at_start_of_list = yes
+	## cardinality = 0..1
+	###Limits species to this gender or removes limit if 'any'
+	gender = enum[genders]
+	## cardinality = 0..1
+	gender = scope[leader]
+	## cardinality = 0..1
+	gender = any
+	###Apply portrait and gender (randomizes new name) changes to existing leaders
+	can_change_leader = bool
 }
 
 ### Re-evaluate the specified casus belli type with given target country

--- a/config/effects.cwt
+++ b/config/effects.cwt
@@ -1809,8 +1809,10 @@ alias[effect:change_species_characteristics] = {
 	###Limits species to this gender or removes limit if 'any'
 	gender = enum[genders]
 	## cardinality = 0..1
+	###Limits species to this gender or removes limit if 'any'
 	gender = scope[leader]
 	## cardinality = 0..1
+	###Limits species to this gender or removes limit if 'any'
 	gender = any
 	###Apply portrait and gender (randomizes new name) changes to existing leaders
 	can_change_leader = bool


### PR DESCRIPTION
Adds support for the 2 new gender-locking features on `change_species_characteristics`

Minor issue with CWTools providing the wrong documentation:

![unknown](https://user-images.githubusercontent.com/5559092/134545228-0948cfea-e759-463c-8fe8-9dda482c4013.png)

Unsure why, because similar config is used for `create_leader = { gender = enum[genders] }` but it gets the correct documentation on hover.