### PR TITLE
Allow multiple resettlement_cost elements and allow each to have multiple resources as part of the cost

### DIFF
--- a/config/common/jobs_and_social_strata.cwt
+++ b/config/common/jobs_and_social_strata.cwt
@@ -184,8 +184,9 @@ social_strata = {
 		alias_name[modifier] = alias_match_left[modifier]
 	}
 
-	## cardinality = 0..1
+	## cardinality = 0..inf
 	resettlement_cost = {
+		## cardinality = 0..inf
 		<resource> = int
 		## cardinality = 0..1
 		trigger = {


### PR DESCRIPTION
Minor fix for syntax changes in 3.0