### PR TITLE
Add missing cardinality - it's not an error to skip this field

### DIFF
--- a/config/effects.cwt
+++ b/config/effects.cwt
@@ -1814,6 +1814,7 @@ alias[effect:change_species_characteristics] = {
 	## cardinality = 0..1
 	###Limits species to this gender or removes limit if 'any'
 	gender = any
+	## cardinality = 0..1
 	###Apply portrait and gender (randomizes new name) changes to existing leaders
 	can_change_leader = bool
 }


### PR DESCRIPTION
I managed to forget the cardinality for `can_change_leader` in #329 - oops.