### PR TITLE
pop_percent effect: cardinality and "exclude" property

### DIFF
--- a/config/triggers.cwt
+++ b/config/triggers.cwt
@@ -169,14 +169,20 @@ alias[trigger:leader_of_faction] = bool
 ###Checks if the current scope and the target scope are the same thing
 alias[trigger:is_same_value] = scope[any]
 
-
 #should check for <> too
 ## replace_scope = { this = pop }
 ###Checks the percentage of pops in the scope that fulfill the specified criteria
 alias[trigger:pop_percentage] = {
+	## cardinality = 0..1
 	limit = {
 		alias_name[trigger] = alias_match_left[trigger]
 	}
+	## cardinality = 0..1
+	###(optional: specifies pops to exclude from the calculation)
+	exclude = {
+		alias_name[trigger] = alias_match_left[trigger]
+	}
+	## required
 	percentage = value_field[0.0..1.0]
 }
 


### PR DESCRIPTION
This is documented in trigger.log but not in CWTools.  The game accepts it properly.

I am assuming the correct cardinality is 0..1, but please update if the game code allows multiple `limit`s and/or `exclude`s.  My testing show that `percentage` is required.

```
pop_percentage - Checks the percentage of pops in the scope that fulfill the specified criteria
pop_percentage = {
	percentage > 0.74/variable
	limit = { <triggers> }
	exclude = { <triggers> } (optional: specifies pops to exclude from the calculation)
}
```