### PR TITLE
species_trait.triggered_planet_growth_modifier

### DIFF
--- a/config/common/common_economic_templates.cwt
+++ b/config/common/common_economic_templates.cwt
@@ -183,7 +183,19 @@ alias[triggered_planet_modifier:triggered_planet_modifier] = {
 		alias_name[modifier] = alias_match_left[modifier]
 	}
 }
-
+## replace_scope = { this = planet root = planet }
+alias[triggered_planet_growth_modifier:triggered_planet_growth_modifier] = {
+	## cardinality = 0..1
+	## replace_scope = { this = pop root = pop }
+	potential = {
+		alias_name[trigger] = alias_match_left[trigger]
+	}
+	alias_name[modifier] = alias_match_left[modifier]
+	## cardinality = 0..1
+	modifier = {
+		alias_name[modifier] = alias_match_left[modifier]
+	}
+}
 ## replace_scope = { this = planet root = planet }
 alias[triggered_planet_modifier_pop:triggered_planet_modifier] = {
 	## cardinality = 0..1

--- a/config/common/traits.cwt
+++ b/config/common/traits.cwt
@@ -88,6 +88,9 @@ trait = {
 		## replace_scope = { this = pop root = pop }
 		###won't show in trait tooltips, use custom_tooltip/custom_tooltip_with_modifiers
 		alias_name[triggered_pop_modifier] = alias_match_left[triggered_pop_modifier]
+		## cardinality = 0..inf
+		## replace_scope = { this = planet root = planet }
+		alias_name[triggered_planet_growth_modifier] = alias_match_left[triggered_planet_growth_modifier]
 		## cardinality = 0..1
 		### Default = yes
 		sapient = bool

--- a/config/common/traits.cwt
+++ b/config/common/traits.cwt
@@ -85,11 +85,9 @@ trait = {
 			alias_name[modifier] = alias_match_left[modifier]
 		}
 		## cardinality = 0..inf
-		## replace_scope = { this = pop root = pop }
 		###won't show in trait tooltips, use custom_tooltip/custom_tooltip_with_modifiers
 		alias_name[triggered_pop_modifier] = alias_match_left[triggered_pop_modifier]
 		## cardinality = 0..inf
-		## replace_scope = { this = planet root = planet }
 		alias_name[triggered_planet_growth_modifier] = alias_match_left[triggered_planet_growth_modifier]
 		## cardinality = 0..1
 		### Default = yes


### PR DESCRIPTION
I believe this is the other missing part alluded to in #337 

This is used (in the game) only for `trait_plantoid_radiotrophic` and `trait_harvested_radiotrophic`.  I did test it and the game does accept planet-scope Pop-modifiers such as `pop_environment_tolerance` here, not only growth-related modifiers.