### PR TITLE
Add ability to use 'ideal_design_class' for moons (like with planets) without error

### DIFF
--- a/config/common/solar_system_initializers.cwt
+++ b/config/common/solar_system_initializers.cwt
@@ -234,6 +234,8 @@ alias[moon_initializer:moon] = {
 	class = star
 	## cardinality = 0..1
 	class = enum[solar_sys_init_planet_class]
+	## cardinality = 0..1
+	class = ideal_design_class
 
 	## cardinality = 0..1
 	orbit_distance = float


### PR DESCRIPTION
I use this successfully on my mod and have no errors show in error.log for Stellaris

In order for "Class = ideal_design_class" to work it needs: init_effect = { set_planet_flag = prescripted_ideal } added to the modifiers for the planet
Examples can be seen in >> "./empire_initializers.txt" (line 863 & 970) << and >> "./sol_initializers.txt" (line 419-423 & 449-454) << located in directory ~./common/solar_system_initializers/