### PR TITLE
3.6 and Inline Scripts

### DIFF
--- a/config/common/jobs_and_social_strata.cwt
+++ b/config/common/jobs_and_social_strata.cwt
@@ -107,6 +107,8 @@ job = {
 	possible_precalc = can_fill_drone_job
 	## cardinality = 0..1
 	possible_precalc = enum[job_triggers]
+	## cardinality = 0..inf
+	inline_script = filepath[common/inline_scripts/,.txt]
 
 	## cardinality = 0..1
 	possible = {
@@ -120,11 +122,15 @@ job = {
 	resources = {
 		category = <economic_category>
 		alias_name[economic_template] = alias_match_left[economic_template]
+		## cardinality = 0..inf
+		inline_script = filepath[common/inline_scripts/,.txt]
 	}
 	## cardinality = 0..1
 	overlord_resources = {
 		category = <economic_category>
 		alias_name[economic_template] = alias_match_left[economic_template]
+		## cardinality = 0..inf
+		inline_script = filepath[common/inline_scripts/,.txt]
 	}
 
 	## cardinality = 0..1
@@ -220,6 +226,8 @@ social_strata = {
 	resources = {
 		category = <economic_category>
 		alias_name[economic_template] = alias_match_left[economic_template]
+		## cardinality = 0..inf
+		inline_script = filepath[common/inline_scripts/,.txt]
 	}
 
 	## cardinality = 0..1
@@ -232,6 +240,8 @@ social_strata = {
 	display_category = <social_strata>
 	## cardinality = 0..1
 	display_unemployment = bool
+	## cardinality = 0..inf
+	inline_script = filepath[common/inline_scripts/,.txt]
 
 	## cardinality = 0..inf
 	alias_name[triggered_planet_modifier_pop] = alias_match_left[triggered_planet_modifier_pop]

--- a/config/logs/modifiers.log
+++ b/config/logs/modifiers.log
@@ -42,6 +42,7 @@ Printing Modifier Definitions:
 - ship_armor_regen_add_static, Category: Ships
 - ship_armor_damage_mult, Category: Ships
 - ship_armor_penetration_mult, Category: Ships
+- ship_armor_hardening_add, Category: Ships
 - ship_shield_add, Category: Ships
 - ship_shield_mult, Category: Ships
 - ship_shield_reduction, Category: Ships
@@ -49,6 +50,7 @@ Printing Modifier Definitions:
 - ship_shield_regen_add_static, Category: Ships
 - ship_shield_damage_mult, Category: Ships
 - ship_shield_penetration_mult, Category: Ships
+- ship_shield_hardening_add, Category: Ships
 - ship_weapon_damage, Category: Ships
 - ship_weapon_range_mult, Category: Ships
 - ship_engagement_range_mult, Category: Ships


### PR DESCRIPTION
Adding support for **inline_scripts** to the *pop_jobs* and *pop_categories* folders in the common directory.  The vanilla files make use of them in **job = {}** and **resources = {}** so I added support for them in those fields.  
Inline scripts require relative file path in *common/inline_scripts/* folder. It is also possible to create sub-folders in the *inline_scripts* folder to organize various scripts.