### PR TITLE
Remove duplicate type definition

### DIFF
--- a/config/common/species_consolidated.cwt
+++ b/config/common/species_consolidated.cwt
@@ -523,7 +523,7 @@ migration_control = {
 		}
 	}
 
-	## cardinality 0..1
+	## cardinality = 0..1
 	can_migrate = no
 
 	## cardinality = 0..1
@@ -658,7 +658,7 @@ population_control = {
 		}
 	}
 
-	## cardinality 0..1
+	## cardinality = 0..1
 	can_reproduce = no
 
 	## cardinality = 0..1
@@ -797,7 +797,7 @@ slavery_type = {
 		}
 	}
 
-	## cardinality 0..1
+	## cardinality = 0..1
 	### otherwise, AI will not colonise with enslaved species
 	ai_can_colonize = yes
 	

--- a/config/common/species_consolidated.cwt
+++ b/config/common/species_consolidated.cwt
@@ -71,9 +71,6 @@ types = {
 	type[species_archetype] = {
 		path = "game/common/species_archetypes"
 	}
-	type[species_archetype] = {
-		path = "game/common/species_archetypes"
-	}
 	type[citizenship_type] = {
 		path = "game/common/species_rights/citizenship_types"
 		localisation = {


### PR DESCRIPTION
* Looks like `type[species_archetype]` was accidentally duplicated when adjusting `species_rights`.
* Add some missing equals signs on species rights types (looks like that was my fault, then propagated by copy/paste)