### PR TITLE
Update projectiles.cwt

### DIFF
--- a/config/gfx/model_entities.cwt
+++ b/config/gfx/model_entities.cwt
@@ -78,7 +78,15 @@ model_entity = {
 		state_time = float
 		## cardinality = 0..1
 		looping = bool
-
+		## cardinality = 0..1
+		propagate_state = { outpost = idle }
+		## cardinality = 0..1
+		propagate_state = { effect = idle }
+		## cardinality = 0..1
+		propagate_state = { move = idle }
+		## cardinality = 0..1
+		propagate_state = { move = moving }
+		
 		#none or one of the two below!
 		## cardinality = 0..1
 		next_state = enum[model_states]
@@ -159,6 +167,10 @@ model_entity = {
 			## cardinality = 0..1
 			entity = <model_entity>
 			## cardinality = 0..1
+			erosion_in = float
+			## cardinality = 0..1
+			erosion_out = float
+			## cardinality = 0..1
 			life = float
 			## cardinality = 0..1
 			particle = <particle>
@@ -227,7 +239,7 @@ model_entity = {
 				length = int
 				#dunno if it works. Seems to be used often so downgraded it because it probably does -Caligula
 				## severity = info
-				## cardinality = 0..0
+				## cardinality = 0..1
 				lenght = int
 				## cardinality = 0..1
 				height = int
@@ -243,11 +255,28 @@ model_entity = {
 		## cardinality = 0..1
 		bloom_factor = float
 		## cardinality = 0..1
+		wpo_animation_speed = float
+		## cardinality = 0..1
+		wpo_animation_direction = { 
+			## cardinality = 0..2
+			float
+		}
+		## cardinality = 0..1
+		wpo_animation_scale = float
+		## cardinality = 0..1
+		wpo_animation_big_scale = float
+		## cardinality = 0..1
+		wpo_animation_offset_strength = float
+		## cardinality = 0..1
 		shader_type = scalar
 		## cardinality = 0..1
 		raytrace_projectiles = bool
 		## cardinality = 0..1
 		custom_texture = filepath
+		## cardinality = 0..1
+		special_effect_intensity = float
+		## cardinality = 0..1
+		special_effect_speed = int
 		## cardinality = 0..1
 		dissolve_on_death = float
 		## cardinality = 0..1
@@ -265,6 +294,8 @@ model_entity = {
 			## cardinality = 3..3
 			float
 		} #XYZ axis coordinates and degrees: 0 0 -14.5
+		## cardinality = 0..1
+		parent_joint = scalar
 		## cardinality = 0..1
 		rotation = {
 			## cardinality = 3..3
@@ -288,6 +319,8 @@ model_entity = {
 		texture_normal = scalar ##TODO filepath #example: "toxic_01_normal.dds"
 		## cardinality = 0..1
 		texture_specular = scalar ##TODO filepath #example: "toxic_01_spec.dds"
+		## cardinality = 0..1
+		texture_wpo = scalar 
 		## cardinality = 0..1
 		shader = scalar #this seems to point to a shader mesh, dunno where its stored. example: "PdxMeshPlanetEmissive". I believe this is stored in a *.mesh file
 	}
@@ -340,7 +373,8 @@ model_mesh = { #the container for all meshes is defined as objectTypes = { at th
 		texture_normal = scalar #filepath
 		## cardinality = 0..1
 		texture_specular = scalar #filepath
-
+		## cardinality = 0..1
+		texture_wpo = scalar 
 	}
 	## cardinality = 0..inf
 	animation = {

--- a/config/interface/projectiles.cwt
+++ b/config/interface/projectiles.cwt
@@ -17,11 +17,13 @@ types = {
 
 projectile = {
 	name = scalar #this is where the projectile key is defined, the
-	color = {
+	color = { 
 		## cardinality = 4..4
-    	float[0..5]
+		float
 	}
+	## cardinality = 0..1
 	hit_entity = <model_entity>
+	## cardinality = 0..1
 	shield_hit_entity = <model_entity>
 	## cardinality = 0..1
 	muzzle_flash_entity = <model_entity>
@@ -39,7 +41,7 @@ projectile = {
 	## cardinality = 0..1
 	hit = {
 		alpha_curve = {
-			## cardinality = 6..12
+			## cardinality = 4..14
 			float
 		}
 		duration = float
@@ -47,11 +49,21 @@ projectile = {
 	## cardinality = 0..1
 	miss = {
 		alpha_curve = {
-			## cardinality = 6..12
+			## cardinality = 4..14
 			float
 		}
 		duration = float
 	}
+	## cardinality = 0..1
+	set_state = {
+		section = attack
+	}
+	## cardinality = 0..1
+	random_scale_multiplier = {
+		min = float
+		max = float
+	}
+	## cardinality = 0..1
 	shield_impact = {
 		size = enum[projectile_impact_size]
 		## cardinality = 0..1
@@ -79,9 +91,9 @@ projectile = {
 
 planet_killer_animation = {
  	texture = filepath
-	color = {
+	color = { 
 		## cardinality = 4..4
-    	float[0..5]
+		float
 	}
 	## cardinality = 0..1
 	planet_dissolve_color_mult = {
@@ -102,19 +114,20 @@ planet_killer_animation = {
 		duration = float
 		## cardinality = 0..1
 		width = {
-			## cardinality = 1..5
-			float float
+			## cardinality = 2..8
+			float 
 		}
 		## cardinality = 0..1
 		texture_scroll_speed = {
-			float float
+			## cardinality = 2..6
+			float
 		}
 		## cardinality = 0..1
 		texture_tiling = float
 		## cardinality = 0..1
 		alpha = {
-			## cardinality = 1..5
-			float float
+			## cardinality = 2..10
+			float
 		}
 	}
 	### If the ship's entity has a state called "kill_planet"
@@ -170,7 +183,6 @@ planet_killer_animation = {
  		}
  		texture_scroll_speed = float
 		texture_tiling = float 
- 		}
  		alpha = {
 			## cardinality = 2..10
 			float

--- a/config/interface/projectiles.cwt
+++ b/config/interface/projectiles.cwt
@@ -18,8 +18,8 @@ types = {
 projectile = {
 	name = scalar #this is where the projectile key is defined, the
 	color = {
-    	## cardinality = 4..4
-		float[0..1]
+		## cardinality = 4..4
+    	float[0..5]
 	}
 	hit_entity = <model_entity>
 	shield_hit_entity = <model_entity>
@@ -80,8 +80,8 @@ projectile = {
 planet_killer_animation = {
  	texture = filepath
 	color = {
-    	## cardinality = 4..4
-		float[0..1]
+		## cardinality = 4..4
+    	float[0..5]
 	}
 	## cardinality = 0..1
 	planet_dissolve_color_mult = {
@@ -102,7 +102,7 @@ planet_killer_animation = {
 		duration = float
 		## cardinality = 0..1
 		width = {
-			## cardinality = 0..4
+			## cardinality = 1..5
 			float float
 		}
 		## cardinality = 0..1
@@ -113,7 +113,7 @@ planet_killer_animation = {
 		texture_tiling = float
 		## cardinality = 0..1
 		alpha = {
-			## cardinality = 0..5
+			## cardinality = 1..5
 			float float
 		}
 	}
@@ -130,7 +130,7 @@ planet_killer_animation = {
  	start = {
  		duration = float
  		width = {
-			## cardinality = 2..8
+			## cardinality = 2..10
 			float
  		}
  		texture_scroll_speed = {
@@ -139,39 +139,40 @@ planet_killer_animation = {
  		}
  		texture_tiling = float
  		alpha = {
-			## cardinality = 4..8
+			## cardinality = 2..10
 			float
  		}
  	}
  	in_progress = {
  		duration = float
  		width = {
-			## cardinality = 2..8
+			## cardinality = 2..10
 			float
  		}
  		texture_scroll_speed = {
-			## cardinality = 2..2
+			## cardinality = 2..6
 			float
  		}
  		texture_tiling = {
 			## cardinality = 2..2
-			float
+			float 
  		}
  		alpha = {
-			## cardinality = 4..8
+			## cardinality = 2..10
 			float
  		}
  	}
  	end = {
  		duration = float
  		width = {
-			## cardinality = 2..8
+			## cardinality = 2..10
 			float
  		}
  		texture_scroll_speed = float
- 		texture_tiling = float
+		texture_tiling = float 
+ 		}
  		alpha = {
-			## cardinality = 4..8
+			## cardinality = 2..10
 			float
  		}
  	}

--- a/config/map/map.cwt
+++ b/config/map/map.cwt
@@ -185,6 +185,8 @@ map_setup_scenario = {
 			## cardinality = 0..1
 			initializer = <solar_system_initializer>
 			## cardinality = 0..1
+			initializer = <solar_system_initializer_random_list>
+			## cardinality = 0..1
 			###Weight for whether an empire should spawn in this system
 			## replace_scope = { this = country root = country }
 			spawn_weight = {

--- a/config/map/map.cwt
+++ b/config/map/map.cwt
@@ -90,18 +90,21 @@ map_setup_scenario = {
 	marauder_empire_default = int
 	marauder_empire_max = int
 	advanced_empire_default = int
+	##cardinality = 0..1
 	colonizable_planet_odds = float
+	##cardinality = 0..1
 	primitive_odds = float
 	crisis_strength = float
+	##cardinality = 0..1
 	extra_crisis_strength = {
 		##cardinality = 1..2
 		int
 	}
 	##cardinality = 0..1
 	default = bool
-
+	##cardinality = 0..1
 	max_hyperlane_distance = float
-
+	##cardinality = 0..1
 	home_system_partitions = {
 		max_systems = int
 		min_systems = int
@@ -111,7 +114,7 @@ map_setup_scenario = {
 
 		method = enum[home_system_method]
 	}
-
+	##cardinality = 0..1
 	open_space_partitions = {
 		max_systems = int
 		min_systems= int
@@ -121,16 +124,19 @@ map_setup_scenario = {
 
 		method = enum[open_space_method]
 	}
-
+	##cardinality = 0..1
 	num_wormhole_pairs = {
 		min = float
 		max = float
 	}
+	##cardinality = 0..1
 	num_wormhole_pairs_default = float
+	##cardinality = 0..1
 	num_gateways = {
 		min = float
 		max = float
 	}
+	##cardinality = 0..1
 	num_gateways_default = float
 	num_hyperlanes = {
 		min = float
@@ -138,7 +144,7 @@ map_setup_scenario = {
 	}
 	num_hyperlanes_default = float
 
-	##cardinality = 1..inf
+	##cardinality = 0..inf
 	supports_shape = <map_galaxy_shape>
 
 	subtype[random] = {


### PR DESCRIPTION
Fix warnings for color and width etc.   Very frustrating to get the warnings to go away.   Note the last color number can be above 1 as paradox uses 5.  I can not find a way to specify it is only the last color number that can be above 1 so I had to allow any of them to be above 1.