### PR TITLE
Make specially defined scripted triggers comparable

### DIFF
--- a/config/common/scripted_effects_and_triggers.cwt
+++ b/config/common/scripted_effects_and_triggers.cwt
@@ -83,16 +83,13 @@ alias[effect:ethic_leader_creator] = {
 }
 
 ### Force scripted trigger to work in common and event files
-alias[trigger:pop_amount] = int_value_field 
+alias[trigger:pop_amount] == int_value_field 
 
 ### Force scripted trigger to work in common and event files
-alias[trigger:sapient_pop_amount] = int_value_field 
+alias[trigger:sapient_pop_amount] == int_value_field 
 
 ### Force scripted trigger to work in common and event files
-alias[trigger:psionic_pop_amount] = int_value_field 
-
-### Force scripted trigger or effect to work in common and event files
-alias[trigger:psionic_pop_amount] = int_value_field 
+alias[trigger:psionic_pop_amount] == int_value_field
 
 ### Force scripted trigger or effect to work in common and event files
 alias[effect:add_random_trait_by_tag] = { 


### PR DESCRIPTION
pop_amount, sapient_pop_amount and psionic_pop_amount should use == instead of = as they are comparable triggers, i.e. can be used in `trigger:trigger_name`.